### PR TITLE
test_ros2_package: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8,17 +8,6 @@ release_platforms:
   ubuntu:
   - jammy
 repositories:
-  test_ros2_package:
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/jpaczia/test_ros2_package.git
-      version: main
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/jpaczia/test_ros2_package-release.git
-      version: 0.0.0
   aandd_ekew_driver_py:
     doc:
       type: git
@@ -10457,6 +10446,22 @@ repositories:
       url: https://github.com/ros2/test_interface_files.git
       version: humble
     status: maintained
+  test_ros2_package:
+    doc:
+      type: git
+      url: https://github.com/jpaczia/test_ros2_package.git
+      version: 0.0.1
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/jpaczia/test_ros2_package-release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/jpaczia/test_ros2_package.git
+      version: main
+    status: developed
   tf_transformations:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `test_ros2_package` to `0.0.1-1`:

- upstream repository: https://github.com/jpaczia/test_ros2_package.git
- release repository: https://github.com/jpaczia/test_ros2_package-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.0`

## test_ros2_package

```
* Setup test ros2 package
* Contributors: Jonas Paczia, jpaczia
```
